### PR TITLE
Add Authentication Instructions to `README.md`

### DIFF
--- a/.github/workflows/docker-ci-pr.yml
+++ b/.github/workflows/docker-ci-pr.yml
@@ -19,6 +19,7 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           docker-images: false
+          swap-storage: false
 
       - name: Clean Old Package Config
         run: sudo apt purge -y '~c'

--- a/.github/workflows/docker-ci-pr.yml
+++ b/.github/workflows/docker-ci-pr.yml
@@ -15,6 +15,14 @@ jobs:
       packages: write
       pull-requests: write
     steps:
+      - name: Free Up Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          docker-images: false
+
+      - name: Clean Old Package Config
+        run: sudo apt purge -y '~c'
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-ci-push.yml
+++ b/.github/workflows/docker-ci-push.yml
@@ -15,6 +15,14 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Free Up Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          docker-images: false
+          
+      - name: Clean Old Package Config
+        run: sudo apt purge -y '~c'
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-ci-push.yml
+++ b/.github/workflows/docker-ci-push.yml
@@ -19,6 +19,7 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           docker-images: false
+          swap-storage: false
           
       - name: Clean Old Package Config
         run: sudo apt purge -y '~c'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ To run GUI apps, go to `localhost:port` in a browser, where `port` is the port n
 
 If you need to run multiple GUI apps at once, and don't want to open a second terminal inside the container, you can run the first command with a `&` character at the end, which will cause it to run in the background.
 
+## Help, Docker can't find the image or can't authenticate to the GitHub Container Registry
+
+To fix this, you will have to authenticate Docker to the GitHub Container Registry. To do this, follow the instructions at [this link](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic). However, I would recommend providing the PAT directly from your clipboard if possible so that it doesn't end up in your shell history. If you do this, do not run the command that has `export` in it. On macOS, one can paste from their clipboard by replacing `echo $CR_PAT` with `pbpaste`.
+
 ## How do I build this container?
 
 In the project directory, run `docker buildx bake --build-arg default.args.ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')`.


### PR DESCRIPTION
Add instructions on how to authenticate Docker to the GitHub Container Registry to `README.md`. 