### PR TITLE
Add Fix to Ensure `xpra` Starts When the Container is Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,6 +151,6 @@ RUN sudo rm /etc/apt/apt.conf.d/01overrides
 
 ENV DISPLAY=:0
 
-RUN xpra start --bind-tcp=0.0.0.0:10000
+RUN echo 'ps cax | grep xpra || xpra start --bind-tcp=0.0.0.0:10000' >> /home/user/.bashrc
 
 EXPOSE 10000

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN dpkg -i /tmp/ros2-apt-source.deb && rm /tmp/ros2-apt-source.deb
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=cache-apt-$TARGETARCH-$TARGETVARIANT \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=lib-apt-$TARGETARCH-$TARGETVARIANT \
-    apt-get update && apt upgrade
+    apt-get update && apt upgrade -y
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Start `xpra` whenever a new `bash` shell starts if it is not already running, instead of starting it when building the image. This makes it so that `xpra` is actually running when the image is run. 