### PR TITLE
Silence Output from `xpra` on Container Start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,6 +151,6 @@ RUN sudo rm /etc/apt/apt.conf.d/01overrides
 
 ENV DISPLAY=:0
 
-RUN echo 'ps cax | grep xpra || xpra start --bind-tcp=0.0.0.0:10000' >> /home/user/.bashrc
+RUN echo 'ps cax | grep xpra || xpra start --bind-tcp=0.0.0.0:10000 2>/dev/null' >> /home/user/.bashrc
 
 EXPOSE 10000

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To run GUI apps, go to `localhost:port` in a browser, where `port` is the port n
 
 If you need to run multiple GUI apps at once, and don't want to open a second terminal inside the container, you can run the first command with a `&` character at the end, which will cause it to run in the background.
 
+**Note:** The timezone in the container is hardcoded to `America/New_York`. If you want to change the timezone, run `sudo dpkg-reconfigure tzdata` in the container.
+
 ## Help, Docker can't find the image or can't authenticate to the GitHub Container Registry
 
 To fix this, you will have to authenticate Docker to the GitHub Container Registry. To do this, follow the instructions at [this link](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic). However, I would recommend providing the PAT directly from your clipboard if possible so that it doesn't end up in your shell history. If you do this, do not run the command that has `export` in it. On macOS, one can paste from their clipboard by replacing `echo $CR_PAT` with `pbpaste`.


### PR DESCRIPTION
Silence the output from `xpra` when starting the container and add a note about the timezone being hardcoded in the container to `README.md`. 