### PR TITLE
Have Docker Container Start in `user`'s Home Folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,4 +155,6 @@ RUN echo 'source /opt/ros/humble/setup.bash' >> /home/user/.bashrc
 
 RUN echo 'ps cax | grep xpra >/dev/null || xpra start --bind-tcp=0.0.0.0:10000 2>/dev/null' >> /home/user/.bashrc
 
+WORKDIR /home/user
+
 EXPOSE 10000


### PR DESCRIPTION
This makes it so that running the container will cause shells to start within `user`'s home folder instead of the last working directory used while building the container. 