### PR TITLE
Try to Fix Shell Used Within Dev Containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ LABEL org.opencontainers.image.authors="cuautodrone"
 
 SHELL ["/bin/bash", "-c"]
 
+ENV SHELL=/bin/bash
+
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 ARG TARGETARCH


### PR DESCRIPTION
This is an attempt to fix the shell used when the container is used as a Dev Container (i.e. using a `devcontainer.json` file) so that it uses `bash` instead of `sh`. 